### PR TITLE
Allow a custom poll time to be set

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,11 +100,23 @@ var GPS = function (hardware, callback) {
   };
   self.setPollTime = function (time) {
     time = parseInt(time, 10);
+    if (isNaN(time)) {
+        time = 2000;
+        if (exports.debug) {
+            console.log('time must be an integer between 2000 and 60000');
+        }
+    }
     if (time < 2000) {
         // No less than 2 seconds
+        if (exports.debug) {
+          console.log("time must be at least 2000ms (2s)");
+        }
         time = 2000;
     } else if (time > 60000) {
         // No more than 60 seconds
+        if (exports.debug) {
+          console.log("time must not be greater than 60000ms (60s)");
+        }
         time = 60000;
     }
     pollTime = time;

--- a/index.js
+++ b/index.js
@@ -93,6 +93,23 @@ var GPS = function (hardware, callback) {
     }
   }, 1000);
 
+  // poll every 2 seconds by default, can bump this up but it'll consume more cpu
+  var pollTime = 2000;
+  self.getPollTime = function () {
+    return pollTime;
+  };
+  self.setPollTime = function (time) {
+    time = parseInt(time, 10);
+    if (time < 2000) {
+        // No less than 2 seconds
+        time = 2000;
+    } else if (time > 60000) {
+        // No more than 60 seconds
+        time = 60000;
+    }
+    pollTime = time;
+    return self;
+  };
 };
 
 util.inherits(GPS, EventEmitter);
@@ -127,7 +144,7 @@ GPS.prototype._checkConnection = function(){
     }
 
     self._checkConnection();
-  }, 2000); // poll every 2 seconds, can bump this up but it'll consume more cpu
+  }, self.getPollTime());
 }
 
 // Toggle the power pin of the A2235-H (attached to hardware.gpio[3]). Assumes the module knows what power state it is in.


### PR DESCRIPTION
Added the ability to set poll time, rather than the hardcoded 2000ms value. It still defaults to 2000 to not break existing behaviour.

There is a guard against the number being used. I've set a lower limit of one second (there was a comment to say it could be bumped lower than two at the cost of cpu). Perhaps that could be put up to two seconds, but in my opinion if someone wanted to sacrifice cpu for a lower poll time that would be up to them. I've also set an upper limit of 60 seconds. That's arbitrary and I didn't really know what to set it to. My thinking was if they wanted longer than 60 seconds they would likely want to put the device into a low power state and wake it up at the time they want a new coordinate.

I have made the variable private so to enforce the limit's of the value and stop accidental modification of the number into something that will not work.