### PR TITLE
Get set poll time test

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,11 +100,23 @@ var GPS = function (hardware, callback) {
   };
   self.setPollTime = function (time) {
     time = parseInt(time, 10);
+    if (isNaN(time)) {
+        time = 2000;
+        if (exports.debug) {
+            console.log('time must be an integer between 2000 and 60000');
+        }
+    }
     if (time < 2000) {
         // No less than 2 seconds
+        if (exports.debug) {
+          console.log("time must be at least 2000ms (2s)");
+        }
         time = 2000;
     } else if (time > 60000) {
         // No more than 60 seconds
+        if (exports.debug) {
+          console.log("time must not be greater than 60000ms (60s)");
+        }
         time = 60000;
     }
     pollTime = time;

--- a/index.js
+++ b/index.js
@@ -93,6 +93,23 @@ var GPS = function (hardware, callback) {
     }
   }, 1000);
 
+  // poll every 2 seconds by default, can bump this up but it'll consume more cpu
+  var pollTime = 2000;
+  self.getPollTime = function () {
+    return pollTime;
+  };
+  self.setPollTime = function (time) {
+    time = parseInt(time, 10);
+    if (time < 2000) {
+        // No less than 2 seconds
+        time = 2000;
+    } else if (time > 60000) {
+        // No more than 60 seconds
+        time = 60000;
+    }
+    pollTime = time;
+    return self;
+  };
 };
 
 util.inherits(GPS, EventEmitter);
@@ -127,7 +144,7 @@ GPS.prototype._checkConnection = function(){
     }
 
     self._checkConnection();
-  }, 2000); // poll every 2 seconds, can bump this up but it'll consume more cpu
+  }, self.getPollTime());
 }
 
 // Toggle the power pin of the A2235-H (attached to hardware.gpio[3]). Assumes the module knows what power state it is in.

--- a/test/getSetPollTime.js
+++ b/test/getSetPollTime.js
@@ -1,0 +1,84 @@
+
+var tessel = require('tessel');
+
+var port = process.argv[2] || 'C';
+var gps = require('../').use(tessel.port[port]);
+var exitStatus = 0;
+
+console.log('# testing on port', port);
+console.log('1..2');
+
+// Test default setting
+if (gps.getPollTime() !== 2000) {
+    console.log('error - expecting default poll time to be 2000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - default poll time is 2000');
+}
+
+// Test set to a value
+gps.setPollTime(4473);
+if (gps.getPollTime() !== 4473) {
+    console.log('error - expecting poll time to be 4473, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 4473 after being set to 4473');
+}
+
+// Test minimum value
+gps.setPollTime(1999);
+if (gps.getPollTime() !== 2000) {
+    console.log('error - expecting minimum poll time to be 2000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 2000 after being set to 1999');
+}
+gps.setPollTime(55);
+if (gps.getPollTime() !== 2000) {
+    console.log('error - expecting minimum poll time to be 2000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 2000 after being set to 55');
+}
+
+// Test maximum value
+gps.setPollTime(60001);
+if (gps.getPollTime() !== 60000) {
+    console.log('error - expecting maximum poll time to be 60000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 60000 after being set to 60001');
+}
+gps.setPollTime(8899983);
+if (gps.getPollTime() !== 60000) {
+    console.log('error - expecting maximum poll time to be 60000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 60000 after being set to 8899983');
+}
+
+// Test invalid values
+gps.setPollTime("testing");
+if (gps.getPollTime() !== 2000) {
+    console.log('error - expecting fallback poll time to be 2000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 2000 after being set to testing');
+}
+gps.setPollTime({time: 4000});
+if (gps.getPollTime() !== 2000) {
+    console.log('error - expecting fallback poll time to be 2000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 2000 after being set to testing');
+}
+gps.setPollTime(function () { return 4000;});
+if (gps.getPollTime() !== 2000) {
+    console.log('error - expecting fallback poll time to be 2000, the value is', gps.getPollTime());
+    exitStatus = 1;
+} else {
+    console.log('ok - poll time is 2000 after being set to testing');
+}
+
+process.exit(exitStatus);
+


### PR DESCRIPTION
I would like to get some feedback on this test case. Running npm test runs the tinytap process, which from looking at the source expects the process to exit 0 to indicate a successful test (standard unix stuff). I must be missing something!

Thank you.