### PR TITLE
Uses unique decimal index for both lat long

### DIFF
--- a/lib/tessel_2/driver.js
+++ b/lib/tessel_2/driver.js
@@ -131,11 +131,12 @@ GPS.prototype._emitCoordinates = function (parsed) {
     var lonPole = parsed.lonPole;
     var lat = parsed.lat;
     var lon = parsed.lon;
-    var dec = lon.indexOf('.');
-    var latDeg = parseFloat(lat.slice(0, dec-2));
-    var latMin = parseFloat(lat.slice(dec-2, lat.length));
-    var lonDeg = parseFloat(lon.slice(0, dec-2));
-    var lonMin = parseFloat(lon.slice(dec-2, lon.length));
+    var decLat = lat.indexOf('.');
+    var decLon = lon.indexOf('.');
+    var latDeg = parseFloat(lat.slice(0, decLat-2));
+    var latMin = parseFloat(lat.slice(decLat-2, lat.length));
+    var lonDeg = parseFloat(lon.slice(0, decLon-2));
+    var lonMin = parseFloat(lon.slice(decLon-2, lon.length));
     var longitude;
     var latitude;
     var latSec;


### PR DESCRIPTION
Instead of depending on latitude and longitude to have the decimal place of their coordinate in the same index of the string, this PR allows them to be different (ie 47.3214 and 127.43243). Otherwise, you end up with coordinates that are invalid.