### PR TITLE
Update coordinator dep to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Kelsey Breseman <kelsey@technical.io>",
   "license": "MIT",
   "dependencies": {
-    "coordinator": "^0.4.7",
+    "coordinator": "^0.5.0",
     "nmea": "0.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
The old coordinator had an obscure dependency on a system tool called `pakmanager`and would spew out an error message on install if the tool was not found:

```
➜  gps npm install gps-a2235h
|
> coordinator@0.4.7 install /Users/Jon/Code/gps/node_modules/gps-a2235h/node_modules/coordinator
> cd examples ; pakmanager build || echo 'Could not build pakmanager package. Please make sure pakmanager is globally installed'

sh: pakmanager: command not found
Could not build pakmanager package. Please make sure pakmanager is globally installed
gps-a2235h@0.3.0 node_modules/gps-a2235h
├── coordinator@0.4.7
└── nmea@0.0.9 (through@2.3.8, JSONStream@0.7.4)
```

As on [0.5.0 this was fixed](https://github.com/beatgammit/node-coordinator/commit/d96a0b1aa1acac98cc3d04b1e06377e74618e79c)